### PR TITLE
GROW-1053 Migrate article versions correctly

### DIFF
--- a/modules/wiki-webcontent-migration/src/main/java/com/liferay/grow/wiki/migration/WikiMigration.java
+++ b/modules/wiki-webcontent-migration/src/main/java/com/liferay/grow/wiki/migration/WikiMigration.java
@@ -20,6 +20,8 @@ package com.liferay.grow.wiki.migration;
  */
 public interface WikiMigration {
 
+	public void migrateWikiPage(long wikiPageResourcePrimKey) throws Exception;
+
 	public void migrateWikis() throws Exception;
 
 }

--- a/modules/wiki-webcontent-migration/src/main/java/com/liferay/grow/wiki/migration/WikiMigrationCommand.java
+++ b/modules/wiki-webcontent-migration/src/main/java/com/liferay/grow/wiki/migration/WikiMigrationCommand.java
@@ -44,6 +44,19 @@ public class WikiMigrationCommand {
 		}
 	}
 
+	public void executeMigration(long wikiPageResourcePrimKey) {
+		try {
+			_wikiMigration.migrateWikiPage(wikiPageResourcePrimKey);
+		}
+		catch (Exception e) {
+			if (e instanceof NoSuchStructureException) {
+				System.out.println("No GROW structure found");
+			}
+
+			e.printStackTrace();
+		}
+	}
+
 	@Reference
 	private WikiMigration _wikiMigration;
 


### PR DESCRIPTION
Hi @hudakl ,

I've changed the versioning logic in migration:
* Added new method to migrate only one article
* Using ActionableDynamicQuery to migrate all version of all articles
* Using addArticle(..) and updateArticle(..) methods to create and update articles
* The child-parent article assignment was changed to run as post-process (there are many articles with null parent, they can be migrated only this way)

Regards,
Vendel